### PR TITLE
NullReference Exception

### DIFF
--- a/ProductionStackTrace.Analyze/SymbolLoader.cs
+++ b/ProductionStackTrace.Analyze/SymbolLoader.cs
@@ -92,6 +92,8 @@ namespace ProductionStackTrace.Analyze
             IDiaSymbol symMethod;
             _session.findSymbolByToken((uint)methodMetadataToken, SymTagEnum.SymTagFunction, out symMethod);
 
+            if (symMethod == null) return null;
+
             var rvaMethod = symMethod.relativeVirtualAddress;
             rvaMethod += (uint)ilOffset;
 


### PR DESCRIPTION
Solved a null reference exception raised if the symbols are not loaded
from the right path and symMethod is null.